### PR TITLE
Task-46145 : Fix jacoco execution

### DIFF
--- a/exo.kernel.commons/pom.xml
+++ b/exo.kernel.commons/pom.xml
@@ -102,7 +102,7 @@
          <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <argLine>${env.MAVEN_OPTS} -Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</argLine>
+              <argLine>${argLine} ${env.MAVEN_OPTS} -Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</argLine>
             </configuration>
          </plugin>
          <plugin>

--- a/exo.kernel.component.cache/pom.xml
+++ b/exo.kernel.component.cache/pom.xml
@@ -69,7 +69,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-                <argLine>${env.MAVEN_OPTS} -Djava.net.preferIPv4Stack=true -Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</argLine>
+                <argLine>${argLine} ${env.MAVEN_OPTS} -Djava.net.preferIPv4Stack=true -Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</argLine>
                 <systemProperties>
                   <!-- Avoid the firewall -->
                   <property>

--- a/exo.kernel.component.common/pom.xml
+++ b/exo.kernel.component.common/pom.xml
@@ -157,7 +157,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-                <argLine>${env.MAVEN_OPTS} -Djava.net.preferIPv4Stack=true -Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</argLine>
+                <argLine>${argLine} ${env.MAVEN_OPTS} -Djava.net.preferIPv4Stack=true -Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</argLine>
                 <systemProperties>
                   <!-- Avoid the firewall -->
                   <property>

--- a/exo.kernel.component.ext.cache.impl.infinispan.v8/pom.xml
+++ b/exo.kernel.component.ext.cache.impl.infinispan.v8/pom.xml
@@ -109,7 +109,7 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
-          <argLine>${env.MAVEN_OPTS} -Djava.net.preferIPv4Stack=true -Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</argLine>
+          <argLine>${argLine} ${env.MAVEN_OPTS} -Djava.net.preferIPv4Stack=true -Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</argLine>
 					<systemProperties>
 						<!-- Avoid the firewall -->
 						<property>

--- a/exo.kernel.component.ext.cache.impl.memcached.v1/pom.xml
+++ b/exo.kernel.component.ext.cache.impl.memcached.v1/pom.xml
@@ -74,7 +74,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-               <argLine>${env.MAVEN_OPTS} -Djava.net.preferIPv4Stack=true -Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</argLine>
+               <argLine>${argLine} ${env.MAVEN_OPTS} -Djava.net.preferIPv4Stack=true -Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</argLine>
                <systemProperties>
                   <property>
                      <name>memcached.locations</name>

--- a/exo.kernel.container.ext.provider.impl.guice.v3/pom.xml
+++ b/exo.kernel.container.ext.provider.impl.guice.v3/pom.xml
@@ -64,7 +64,7 @@
          <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <argLine>${env.MAVEN_OPTS} -Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</argLine>
+              <argLine>${argLine} ${env.MAVEN_OPTS} -Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</argLine>
             </configuration>
          </plugin>
          <plugin>

--- a/exo.kernel.container/pom.xml
+++ b/exo.kernel.container/pom.xml
@@ -115,7 +115,7 @@
          <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <argLine>${env.MAVEN_OPTS} -Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</argLine>
+              <argLine>${argLine} ${env.MAVEN_OPTS} -Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</argLine>
             </configuration>
          </plugin>
          <plugin>


### PR DESCRIPTION
Before this fix, jacoco does not fail if target ratio is not reached.
This is due to the fact that surefire override jacoco argLine and jacoco option are not more usable
This fix follow this https://stackoverflow.com/questions/12269558/maven-jacoco-plugin-error and re-add ${argLine} in surefire option, so that jacoco is able to find his options