### PR TITLE
TASK-53370 Enhance Unit Test to avoid a random fail

### DIFF
--- a/exo.kernel.component.common/src/test/java/org/exoplatform/services/rpc/impl/TestRPCServiceImpl.java
+++ b/exo.kernel.component.common/src/test/java/org/exoplatform/services/rpc/impl/TestRPCServiceImpl.java
@@ -287,7 +287,7 @@ public class TestRPCServiceImpl extends TestCase
          }
          try
          {
-            service.executeCommandOnCoordinator(foo, 10);
+            service.executeCommandOnCoordinator(foo, 100);
             fail("We expect a RPCException since the current state is not the expected one");
          }
          catch (RPCException e)
@@ -306,9 +306,9 @@ public class TestRPCServiceImpl extends TestCase
          service.start();
          assertEquals(true, service.isCoordinator());
          service.executeCommandOnAllNodes(foo, true);
-         service.executeCommandOnAllNodes(foo, 10);
+         service.executeCommandOnAllNodes(foo, 100);
          service.executeCommandOnCoordinator(foo, true);
-         service.executeCommandOnCoordinator(foo, 10);
+         service.executeCommandOnCoordinator(foo, 100);
       }
       finally
       {
@@ -346,7 +346,7 @@ public class TestRPCServiceImpl extends TestCase
       }
       try
       {
-         service.executeCommandOnCoordinator(foo, 10);
+         service.executeCommandOnCoordinator(foo, 100);
          fail("We expect a RPCException since the current state is not the expected one");
       }
       catch (RPCException e)


### PR DESCRIPTION
Prior to this change, a timeout is sometimes observed due to the fact that we use a very small timeout in Milliseconds (10) in unit tests that can fail when the used machine isn't sufficiently performant. This fix will increase the timeout to 100ms.