### PR TITLE
MEED-196 Allow to mock ListenerService in Unit Tests

### DIFF
--- a/exo.kernel.component.common/src/main/java/org/exoplatform/services/listener/ListenerService.java
+++ b/exo.kernel.component.common/src/main/java/org/exoplatform/services/listener/ListenerService.java
@@ -173,7 +173,7 @@ public class ListenerService implements Startable
     * @param data The data object instance
     * @throws Exception if an exception occurs
     */
-   final public <S, D> void broadcast(String name, S source, D data) throws Exception
+   public <S, D> void broadcast(String name, S source, D data) throws Exception
    {
       List<Listener> list = listeners_.get(name);
       if (list == null)
@@ -208,7 +208,7 @@ public class ListenerService implements Startable
     * @param event The event instance
     * @throws Exception
     */
-   final public <T extends Event> void broadcast(T event) throws Exception
+   public <T extends Event> void broadcast(T event) throws Exception
    {
       List<Listener> list = listeners_.get(event.getEventName());
       if (list == null)


### PR DESCRIPTION
Prior tot his change when mocking ListenerService using Mockito, the `broadcast` method can't be mocked easily since it's final. This change will delete useless final modifier on public methods.