### PR TITLE
fix : avoid filtering configuration files EXO-59810

### DIFF
--- a/exo.kernel.container/src/main/java/org/exoplatform/container/util/ContainerUtil.java
+++ b/exo.kernel.container/src/main/java/org/exoplatform/container/util/ContainerUtil.java
@@ -22,7 +22,6 @@ import javassist.util.proxy.MethodFilter;
 import javassist.util.proxy.MethodHandler;
 import javassist.util.proxy.ProxyFactory;
 
-import org.exoplatform.commons.Environment;
 import org.exoplatform.commons.utils.ClassLoading;
 import org.exoplatform.commons.utils.PropertiesLoader;
 import org.exoplatform.commons.utils.SecurityHelper;
@@ -66,7 +65,6 @@ import javax.inject.Scope;
 import javax.inject.Singleton;
 import javax.servlet.ServletContext;
 
-import static org.exoplatform.commons.Environment.JBOSS_PLATFORM;
 
 /**
  * @author Tuan Nguyen (tuan08@users.sourceforge.net)

--- a/exo.kernel.container/src/main/java/org/exoplatform/container/util/ContainerUtil.java
+++ b/exo.kernel.container/src/main/java/org/exoplatform/container/util/ContainerUtil.java
@@ -22,6 +22,7 @@ import javassist.util.proxy.MethodFilter;
 import javassist.util.proxy.MethodHandler;
 import javassist.util.proxy.ProxyFactory;
 
+import org.exoplatform.commons.Environment;
 import org.exoplatform.commons.utils.ClassLoading;
 import org.exoplatform.commons.utils.PropertiesLoader;
 import org.exoplatform.commons.utils.SecurityHelper;
@@ -64,6 +65,8 @@ import javax.inject.Provider;
 import javax.inject.Scope;
 import javax.inject.Singleton;
 import javax.servlet.ServletContext;
+
+import static org.exoplatform.commons.Environment.JBOSS_PLATFORM;
 
 /**
  * @author Tuan Nguyen (tuan08@users.sourceforge.net)
@@ -299,16 +302,6 @@ public class ContainerUtil
          {
             continue;
          }
-         // jboss bug, jboss has a very weird behavior. It copy all the jar files
-         // and
-         // deploy them to a temp dir and include both jars, the one in sar and tmp
-         // dir,
-         // in the class path. It cause the configuration run twice
-         int index1 = key.lastIndexOf("exo-");
-         int index2 = key.lastIndexOf("exo.");
-         int index = index1 < index2 ? index2 : index1;
-         if (index >= 0)
-            key = key.substring(index);
          map.put(key, url);
       }
 


### PR DESCRIPTION
After adding the term **-exo-** to the version of the eXo modules, Gatein-portal and commons unit tests were failing. 
The problem cause was an errouneous filtering in the kernel module that modify the configuration.xml path when its path contains **exo.** or **exo-** , this leads to creating a PortalContainer with missing services configurations. This code was removed as it is not viable and was added just to workaround an old problem with Jboss AS servers which are no more supported since a while
