### PR TITLE
fix : avoid filtering configuration files - EXO-59810 - Meeds-io/meeds-305

### DIFF
--- a/exo.kernel.container/src/main/java/org/exoplatform/container/util/ContainerUtil.java
+++ b/exo.kernel.container/src/main/java/org/exoplatform/container/util/ContainerUtil.java
@@ -65,6 +65,7 @@ import javax.inject.Scope;
 import javax.inject.Singleton;
 import javax.servlet.ServletContext;
 
+
 /**
  * @author Tuan Nguyen (tuan08@users.sourceforge.net)
  * @since Oct 28, 2004
@@ -299,16 +300,6 @@ public class ContainerUtil
          {
             continue;
          }
-         // jboss bug, jboss has a very weird behavior. It copy all the jar files
-         // and
-         // deploy them to a temp dir and include both jars, the one in sar and tmp
-         // dir,
-         // in the class path. It cause the configuration run twice
-         int index1 = key.lastIndexOf("exo-");
-         int index2 = key.lastIndexOf("exo.");
-         int index = index1 < index2 ? index2 : index1;
-         if (index >= 0)
-            key = key.substring(index);
          map.put(key, url);
       }
 


### PR DESCRIPTION
After adding the term -exo- to the version of the eXo modules, Gatein-portal and commons unit tests were failing. 
The problem cause was an errouneous filtering in the kernel module that modify the configuration.xml path when its path contains **exo.** or **exo-** , this leads to creating a PortalContainer with missing services configurations. 
The filtering code was removed as it is not viable and was added just to workaround an old problem with Jboss AS servers which are no more supported since a while