### PR TITLE
feat: stabilize kernel with JDK 17 - EXO-60318

### DIFF
--- a/exo.kernel.commons/src/main/java/org/exoplatform/commons/debug/ObjectDebuger.java
+++ b/exo.kernel.commons/src/main/java/org/exoplatform/commons/debug/ObjectDebuger.java
@@ -30,8 +30,8 @@ import java.util.Map;
 /**
  * Jul 29, 2004
  * 
- * @author: Tuan Nguyen
- * @version: $Id: ObjectDebuger.java,v 1.4 2004/09/21 00:04:43 tuan08 Exp $
+ * @author Tuan Nguyen
+ * @version $Id: ObjectDebuger.java,v 1.4 2004/09/21 00:04:43 tuan08 Exp $
  */
 public class ObjectDebuger
 {

--- a/exo.kernel.commons/src/main/java/org/exoplatform/commons/exception/ExoException.java
+++ b/exo.kernel.commons/src/main/java/org/exoplatform/commons/exception/ExoException.java
@@ -21,9 +21,9 @@ package org.exoplatform.commons.exception;
 import java.util.ResourceBundle;
 
 /**
- * @author: Tuan Nguyen
- * @version: $Id: ExoException.java,v 1.5 2004/11/03 01:24:55 tuan08 Exp $
- * @since: 0.0
+ * @author Tuan Nguyen
+ * @version $Id: ExoException.java,v 1.5 2004/11/03 01:24:55 tuan08 Exp $
+ * @since 0.0
  */
 abstract public class ExoException extends Exception
 {

--- a/exo.kernel.commons/src/main/java/org/exoplatform/commons/utils/ExceptionUtil.java
+++ b/exo.kernel.commons/src/main/java/org/exoplatform/commons/utils/ExceptionUtil.java
@@ -21,8 +21,8 @@ package org.exoplatform.commons.utils;
 /**
  * Jul 8, 2004
  * 
- * @author: Tuan Nguyen
- * @version: $Id: ExceptionUtil.java,v 1.2 2004/10/05 14:40:47 tuan08 Exp $
+ * @author Tuan Nguyen
+ * @version $Id: ExceptionUtil.java,v 1.2 2004/10/05 14:40:47 tuan08 Exp $
  */
 public class ExceptionUtil
 {

--- a/exo.kernel.commons/src/main/java/org/exoplatform/commons/utils/ExoProperties.java
+++ b/exo.kernel.commons/src/main/java/org/exoplatform/commons/utils/ExoProperties.java
@@ -26,8 +26,8 @@ import java.util.Set;
 /**
  * Jul 20, 2004
  * 
- * @author: Tuan Nguyen
- * @version: $Id: ExoProperties.java,v 1.1 2004/09/11 14:08:53 tuan08 Exp $
+ * @author Tuan Nguyen
+ * @version $Id: ExoProperties.java,v 1.1 2004/09/11 14:08:53 tuan08 Exp $
  */
 public class ExoProperties extends LinkedHashMap<String, String>
 {

--- a/exo.kernel.commons/src/main/java/org/exoplatform/commons/utils/ExpressionUtil.java
+++ b/exo.kernel.commons/src/main/java/org/exoplatform/commons/utils/ExpressionUtil.java
@@ -26,8 +26,8 @@ import java.util.ResourceBundle;
 /**
  * Jul 18, 2004
  * 
- * @author: Tuan Nguyen
- * @version: $Id: ExpressionUtil.java,v 1.1 2004/07/21 19:59:11 tuan08 Exp $
+ * @author Tuan Nguyen
+ * @version $Id: ExpressionUtil.java,v 1.1 2004/07/21 19:59:11 tuan08 Exp $
  */
 public class ExpressionUtil
 {

--- a/exo.kernel.commons/src/main/java/org/exoplatform/commons/utils/IOUtil.java
+++ b/exo.kernel.commons/src/main/java/org/exoplatform/commons/utils/IOUtil.java
@@ -32,9 +32,9 @@ import java.io.ObjectOutputStream;
 import java.net.URL;
 
 /**
- * @author: Tuan Nguyen
- * @version: $Id: IOUtil.java,v 1.4 2004/09/14 02:41:19 tuan08 Exp $
- * @since: 0.0
+ * @author Tuan Nguyen
+ * @version $Id: IOUtil.java,v 1.4 2004/09/14 02:41:19 tuan08 Exp $
+ * @since 0.0
  */
 public class IOUtil
 {

--- a/exo.kernel.commons/src/main/java/org/exoplatform/commons/utils/IdentifierUtil.java
+++ b/exo.kernel.commons/src/main/java/org/exoplatform/commons/utils/IdentifierUtil.java
@@ -27,8 +27,8 @@ import java.security.SecureRandom;
 /**
  * Jul 19, 2004
  * 
- * @author: Tuan Nguyen
- * @version: $Id: IdentifierUtil.java,v 1.1 2004/07/20 12:22:42 tuan08 Exp $
+ * @author Tuan Nguyen
+ * @version $Id: IdentifierUtil.java,v 1.1 2004/07/20 12:22:42 tuan08 Exp $
  */
 public class IdentifierUtil
 {

--- a/exo.kernel.commons/src/main/java/org/exoplatform/commons/xml/ExoXMLSerializer.java
+++ b/exo.kernel.commons/src/main/java/org/exoplatform/commons/xml/ExoXMLSerializer.java
@@ -23,8 +23,8 @@ import org.xmlpull.mxp1_serializer.MXSerializer;
 /**
  * Jul 8, 2004
  * 
- * @author: Tuan Nguyen
- * @version: $Id: ExoXMLSerializer.java,v 1.1 2004/07/08 19:24:47 tuan08 Exp $
+ * @author Tuan Nguyen
+ * @version $Id: ExoXMLSerializer.java,v 1.1 2004/07/08 19:24:47 tuan08 Exp $
  */
 public class ExoXMLSerializer extends MXSerializer
 {

--- a/exo.kernel.commons/src/main/java/org/exoplatform/commons/xml/ExoXPPParser.java
+++ b/exo.kernel.commons/src/main/java/org/exoplatform/commons/xml/ExoXPPParser.java
@@ -24,8 +24,8 @@ import org.xmlpull.v1.XmlPullParser;
 /**
  * Jul 8, 2004
  * 
- * @author: Tuan Nguyen
- * @version: $Id: ExoXPPParser.java,v 1.4 2004/10/20 20:58:27 tuan08 Exp $
+ * @author Tuan Nguyen
+ * @version $Id: ExoXPPParser.java,v 1.4 2004/10/20 20:58:27 tuan08 Exp $
  */
 public class ExoXPPParser extends MXParserCachingStrings
 {

--- a/exo.kernel.component.ext.cache.impl.infinispan.v8/pom.xml
+++ b/exo.kernel.component.ext.cache.impl.infinispan.v8/pom.xml
@@ -99,7 +99,7 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
-          <argLine>@{argLine} ${env.MAVEN_OPTS} -Djava.net.preferIPv4Stack=true -Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</argLine>
+            <argLine>@{argLine} ${env.MAVEN_OPTS} --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED  -Djava.net.preferIPv4Stack=true -Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</argLine>
 					<systemProperties>
 						<!-- Avoid the firewall -->
 						<property>
@@ -113,8 +113,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/exo.kernel.container.ext.provider.impl.guice.v3/pom.xml
+++ b/exo.kernel.container.ext.provider.impl.guice.v3/pom.xml
@@ -53,13 +53,22 @@
          <artifactId>exo.kernel.commons.test</artifactId>
          <scope>test</scope>
       </dependency>
+       <dependency>
+           <groupId>org.exoplatform.kernel</groupId>
+           <artifactId>exo.kernel.container</artifactId>
+           <scope>test</scope>
+       </dependency>
+      <dependency>
+         <groupId>org.exoplatform.kernel</groupId>
+         <artifactId>exo.kernel.container</artifactId>
+      </dependency>
    </dependencies>
    <build>
       <plugins>
          <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <argLine>@{argLine} ${env.MAVEN_OPTS} -Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</argLine>
+              <argLine>@{argLine} ${env.MAVEN_OPTS} --add-opens=java.base/java.lang=ALL-UNNAMED -Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</argLine>
             </configuration>
          </plugin>
          <plugin>

--- a/exo.kernel.container.ext.provider.impl.guice.v3/pom.xml
+++ b/exo.kernel.container.ext.provider.impl.guice.v3/pom.xml
@@ -53,15 +53,6 @@
          <artifactId>exo.kernel.commons.test</artifactId>
          <scope>test</scope>
       </dependency>
-       <dependency>
-           <groupId>org.exoplatform.kernel</groupId>
-           <artifactId>exo.kernel.container</artifactId>
-           <scope>test</scope>
-       </dependency>
-      <dependency>
-         <groupId>org.exoplatform.kernel</groupId>
-         <artifactId>exo.kernel.container</artifactId>
-      </dependency>
    </dependencies>
    <build>
       <plugins>

--- a/exo.kernel.container/src/main/java/org/exoplatform/test/MockConfigurationManagerImpl.java
+++ b/exo.kernel.container/src/main/java/org/exoplatform/test/MockConfigurationManagerImpl.java
@@ -31,8 +31,8 @@ import javax.servlet.ServletContext;
 /**
  * Jul 19, 2004
  * 
- * @author: Tuan Nguyen
- * @version: $Id: MockConfigurationManagerImpl.java 5799 2006-05-28 17:55:42Z
+ * @author Tuan Nguyen
+ * @version $Id: MockConfigurationManagerImpl.java 5799 2006-05-28 17:55:42Z
  *           geaz $
  */
 public class MockConfigurationManagerImpl extends ConfigurationManagerImpl


### PR DESCRIPTION
prior to this change, when upgrading to JDK 17 kernel throws many exceptions and fails when building: " module java.base does not opens java.util", "Source option 6 is no longer supported. Use 7 or later." ....
. This change will fix these errors.