### PR TITLE
fix : random error in kernel Unit tests - EXO-60598

### DIFF
--- a/exo.kernel.container/src/test/java/org/exoplatform/container/log/TestLoggers.java
+++ b/exo.kernel.container/src/test/java/org/exoplatform/container/log/TestLoggers.java
@@ -38,16 +38,12 @@ public class TestLoggers extends TestCase
 
    public void testLog4jContainer() throws Exception
    {
-
-      PortalContainer.getInstance();
       Log log = ExoLogger.getLogger(TestLoggers.class);
-
       log.info("Log4j Container Tests");
       log.info("Log4j Container {}", "Tests");
       log.info("Log4j Conta{} Te{}", "iner", "sts");
       log.info("Log4j Container Tests", 1, 2, 3);
       logOut(log);
-
    }
 
 


### PR DESCRIPTION
This patch will fix the random error in Kernel module by removing the ```PortalContainer.getInstance()``` as there is no need for it for Loggers testing