### PR TITLE
fix : random error in kernel Unit tests - EXO-60598 - meeds-io/meeds#376

### DIFF
--- a/exo.kernel.container/src/test/java/org/exoplatform/container/log/TestLoggers.java
+++ b/exo.kernel.container/src/test/java/org/exoplatform/container/log/TestLoggers.java
@@ -38,16 +38,12 @@ public class TestLoggers extends TestCase
 
    public void testLog4jContainer() throws Exception
    {
-
-      PortalContainer.getInstance();
       Log log = ExoLogger.getLogger(TestLoggers.class);
-
       log.info("Log4j Container Tests");
       log.info("Log4j Container {}", "Tests");
       log.info("Log4j Conta{} Te{}", "iner", "sts");
       log.info("Log4j Container Tests", 1, 2, 3);
       logOut(log);
-
    }
 
 


### PR DESCRIPTION
(cherry picked from commit 08b6166f8522a8aa6d2e8f6da3505d71700779a8)

Unit test in org.exoplatform.container.log.TestLoggers.testLog4jContainer is failing when trying to build the Portal container. But there is no need to have a Portal container for testing loggers, thus the fix will remove the instruction that builds it.

