### PR TITLE
feat: stabilize kernel with JDK 17 - EXO-60318 - Meeds-io/MIPs#26

### DIFF
--- a/exo.kernel.commons/src/main/java/org/exoplatform/commons/debug/ObjectDebuger.java
+++ b/exo.kernel.commons/src/main/java/org/exoplatform/commons/debug/ObjectDebuger.java
@@ -30,8 +30,8 @@ import java.util.Map;
 /**
  * Jul 29, 2004
  * 
- * @author: Tuan Nguyen
- * @version: $Id: ObjectDebuger.java,v 1.4 2004/09/21 00:04:43 tuan08 Exp $
+ * @author Tuan Nguyen
+ * @version $Id: ObjectDebuger.java,v 1.4 2004/09/21 00:04:43 tuan08 Exp $
  */
 public class ObjectDebuger
 {

--- a/exo.kernel.commons/src/main/java/org/exoplatform/commons/exception/ExoException.java
+++ b/exo.kernel.commons/src/main/java/org/exoplatform/commons/exception/ExoException.java
@@ -21,9 +21,9 @@ package org.exoplatform.commons.exception;
 import java.util.ResourceBundle;
 
 /**
- * @author: Tuan Nguyen
- * @version: $Id: ExoException.java,v 1.5 2004/11/03 01:24:55 tuan08 Exp $
- * @since: 0.0
+ * @author Tuan Nguyen
+ * @version $Id: ExoException.java,v 1.5 2004/11/03 01:24:55 tuan08 Exp $
+ * @since 0.0
  */
 abstract public class ExoException extends Exception
 {

--- a/exo.kernel.commons/src/main/java/org/exoplatform/commons/exception/ExoMessageException.java
+++ b/exo.kernel.commons/src/main/java/org/exoplatform/commons/exception/ExoMessageException.java
@@ -22,7 +22,7 @@ import java.text.MessageFormat;
 import java.util.ResourceBundle;
 
 /*
- * @author: Tuan Nguyen
+ * @author Tuan Nguyen
  * @version: $Id: ExoMessageException.java,v 1.2 2004/11/03 01:24:55 tuan08 Exp $
  * @since: 0.0
  */

--- a/exo.kernel.commons/src/main/java/org/exoplatform/commons/exception/ObjectNotFoundException.java
+++ b/exo.kernel.commons/src/main/java/org/exoplatform/commons/exception/ObjectNotFoundException.java
@@ -19,9 +19,9 @@
 package org.exoplatform.commons.exception;
 
 /*
- * @author: Tuan Nguyen
- * @version: $Id: ObjectNotFoundException.java,v 1.2 2004/04/06 21:07:18 tuan08 Exp $
- * @since: 0.0
+ * @author Tuan Nguyen
+ * @version $Id: ObjectNotFoundException.java,v 1.2 2004/04/06 21:07:18 tuan08 Exp $
+ * @since 0.0
  */
 public class ObjectNotFoundException extends Exception
 {

--- a/exo.kernel.commons/src/main/java/org/exoplatform/commons/exception/UniqueObjectException.java
+++ b/exo.kernel.commons/src/main/java/org/exoplatform/commons/exception/UniqueObjectException.java
@@ -19,9 +19,9 @@
 package org.exoplatform.commons.exception;
 
 /*
- * @author: Tuan Nguyen
- * @version: $Id: UniqueObjectException.java,v 1.1 2004/10/21 15:23:40 tuan08 Exp $
- * @since: 0.0
+ * @author Tuan Nguyen
+ * @version $Id: UniqueObjectException.java,v 1.1 2004/10/21 15:23:40 tuan08 Exp $
+ * @since 0.0
  */
 public class UniqueObjectException extends ExoMessageException
 {

--- a/exo.kernel.commons/src/main/java/org/exoplatform/commons/utils/ExceptionUtil.java
+++ b/exo.kernel.commons/src/main/java/org/exoplatform/commons/utils/ExceptionUtil.java
@@ -21,8 +21,8 @@ package org.exoplatform.commons.utils;
 /**
  * Jul 8, 2004
  * 
- * @author: Tuan Nguyen
- * @version: $Id: ExceptionUtil.java,v 1.2 2004/10/05 14:40:47 tuan08 Exp $
+ * @author Tuan Nguyen
+ * @version $Id: ExceptionUtil.java,v 1.2 2004/10/05 14:40:47 tuan08 Exp $
  */
 public class ExceptionUtil
 {

--- a/exo.kernel.commons/src/main/java/org/exoplatform/commons/utils/ExoEnumeration.java
+++ b/exo.kernel.commons/src/main/java/org/exoplatform/commons/utils/ExoEnumeration.java
@@ -19,8 +19,8 @@
 package org.exoplatform.commons.utils;
 
 /** * Jul 11, 2004 
- * @author: Tuan Nguyen
- * @version: $Id: ExoEnumeration.java,v 1.3 2004/07/13 02:46:19 tuan08 Exp $
+ * @author Tuan Nguyen
+ * @version $Id: ExoEnumeration.java,v 1.3 2004/07/13 02:46:19 tuan08 Exp $
  */
 
 import java.util.Enumeration;

--- a/exo.kernel.commons/src/main/java/org/exoplatform/commons/utils/ExoProperties.java
+++ b/exo.kernel.commons/src/main/java/org/exoplatform/commons/utils/ExoProperties.java
@@ -26,8 +26,8 @@ import java.util.Set;
 /**
  * Jul 20, 2004
  * 
- * @author: Tuan Nguyen
- * @version: $Id: ExoProperties.java,v 1.1 2004/09/11 14:08:53 tuan08 Exp $
+ * @author Tuan Nguyen
+ * @version $Id: ExoProperties.java,v 1.1 2004/09/11 14:08:53 tuan08 Exp $
  */
 public class ExoProperties extends LinkedHashMap<String, String>
 {

--- a/exo.kernel.commons/src/main/java/org/exoplatform/commons/utils/ExpressionUtil.java
+++ b/exo.kernel.commons/src/main/java/org/exoplatform/commons/utils/ExpressionUtil.java
@@ -26,8 +26,8 @@ import java.util.ResourceBundle;
 /**
  * Jul 18, 2004
  * 
- * @author: Tuan Nguyen
- * @version: $Id: ExpressionUtil.java,v 1.1 2004/07/21 19:59:11 tuan08 Exp $
+ * @author Tuan Nguyen
+ * @version $Id: ExpressionUtil.java,v 1.1 2004/07/21 19:59:11 tuan08 Exp $
  */
 public class ExpressionUtil
 {

--- a/exo.kernel.commons/src/main/java/org/exoplatform/commons/utils/IOUtil.java
+++ b/exo.kernel.commons/src/main/java/org/exoplatform/commons/utils/IOUtil.java
@@ -32,9 +32,9 @@ import java.io.ObjectOutputStream;
 import java.net.URL;
 
 /**
- * @author: Tuan Nguyen
- * @version: $Id: IOUtil.java,v 1.4 2004/09/14 02:41:19 tuan08 Exp $
- * @since: 0.0
+ * @author Tuan Nguyen
+ * @version $Id: IOUtil.java,v 1.4 2004/09/14 02:41:19 tuan08 Exp $
+ * @since 0.0
  */
 public class IOUtil
 {

--- a/exo.kernel.commons/src/main/java/org/exoplatform/commons/utils/IdentifierUtil.java
+++ b/exo.kernel.commons/src/main/java/org/exoplatform/commons/utils/IdentifierUtil.java
@@ -27,8 +27,8 @@ import java.security.SecureRandom;
 /**
  * Jul 19, 2004
  * 
- * @author: Tuan Nguyen
- * @version: $Id: IdentifierUtil.java,v 1.1 2004/07/20 12:22:42 tuan08 Exp $
+ * @author Tuan Nguyen
+ * @version $Id: IdentifierUtil.java,v 1.1 2004/07/20 12:22:42 tuan08 Exp $
  */
 public class IdentifierUtil
 {

--- a/exo.kernel.commons/src/main/java/org/exoplatform/commons/xml/ExoXMLSerializer.java
+++ b/exo.kernel.commons/src/main/java/org/exoplatform/commons/xml/ExoXMLSerializer.java
@@ -23,8 +23,8 @@ import org.xmlpull.mxp1_serializer.MXSerializer;
 /**
  * Jul 8, 2004
  * 
- * @author: Tuan Nguyen
- * @version: $Id: ExoXMLSerializer.java,v 1.1 2004/07/08 19:24:47 tuan08 Exp $
+ * @author Tuan Nguyen
+ * @version $Id: ExoXMLSerializer.java,v 1.1 2004/07/08 19:24:47 tuan08 Exp $
  */
 public class ExoXMLSerializer extends MXSerializer
 {

--- a/exo.kernel.commons/src/main/java/org/exoplatform/commons/xml/ExoXPPParser.java
+++ b/exo.kernel.commons/src/main/java/org/exoplatform/commons/xml/ExoXPPParser.java
@@ -24,8 +24,8 @@ import org.xmlpull.v1.XmlPullParser;
 /**
  * Jul 8, 2004
  * 
- * @author: Tuan Nguyen
- * @version: $Id: ExoXPPParser.java,v 1.4 2004/10/20 20:58:27 tuan08 Exp $
+ * @author Tuan Nguyen
+ * @version $Id: ExoXPPParser.java,v 1.4 2004/10/20 20:58:27 tuan08 Exp $
  */
 public class ExoXPPParser extends MXParserCachingStrings
 {

--- a/exo.kernel.component.cache/src/test/java/org/exoplatform/services/cache/test/TestCacheService.java
+++ b/exo.kernel.component.cache/src/test/java/org/exoplatform/services/cache/test/TestCacheService.java
@@ -51,9 +51,9 @@ import javax.management.ObjectName;
 
 /*
  * Thu, May 15, 2003 @   
- * @author: Tuan Nguyen
- * @version: $Id: TestCacheService.java 5799 2006-05-28 17:55:42Z geaz $
- * @since: 0.0
+ * @author Tuan Nguyen
+ * @version $Id: TestCacheService.java 5799 2006-05-28 17:55:42Z geaz $
+ * @since 0.0
  */
 public class TestCacheService extends TestCase
 {

--- a/exo.kernel.component.common/src/main/java/org/exoplatform/services/exception/ExoServiceException.java
+++ b/exo.kernel.component.common/src/main/java/org/exoplatform/services/exception/ExoServiceException.java
@@ -22,9 +22,9 @@ import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 
 /**
- * @author: Tuan Nguyen
- * @version: $Id: ExoServiceException.java 5332 2006-04-29 18:32:44Z geaz $
- * @since: 0.0
+ * @author Tuan Nguyen
+ * @version $Id: ExoServiceException.java 5332 2006-04-29 18:32:44Z geaz $
+ * @since 0.0
  */
 public class ExoServiceException extends Exception
 {

--- a/exo.kernel.component.common/src/main/java/org/exoplatform/services/rpc/SingleMethodCallCommand.java
+++ b/exo.kernel.component.common/src/main/java/org/exoplatform/services/rpc/SingleMethodCallCommand.java
@@ -61,14 +61,14 @@ public class SingleMethodCallCommand implements RemoteCommand
      *             <ul>
      *
      *             <li> invocation of 
-     *             <tt>{@link SecurityManager#checkMemberAccess
-     *             s.checkMemberAccess(this, Member.DECLARED)}</tt> denies
+     *             <code>{@link SecurityManager #checkMemberAccess
+     *             s.checkMemberAccess(this, Member.DECLARED)}</code> denies
      *             access to the declared method
      *
      *             <li> the caller's class loader is not the same as or an
      *             ancestor of the class loader for the current class and
-     *             invocation of <tt>{@link SecurityManager#checkPackageAccess
-     *             s.checkPackageAccess()}</tt> denies access to the package
+     *             invocation of <code>{@link SecurityManager#checkPackageAccess
+     *             s.checkPackageAccess()}</code> denies access to the package
      *             of this class
      *
      *             </ul>

--- a/exo.kernel.component.common/src/main/java/org/exoplatform/services/transaction/ActionNonTxAware.java
+++ b/exo.kernel.component.common/src/main/java/org/exoplatform/services/transaction/ActionNonTxAware.java
@@ -84,7 +84,7 @@ public abstract class ActionNonTxAware<R, A, E extends Exception>
    /**
     * Executes the action outside the context of the current tx. This
     * method is equivalent to {@link ActionNonTxAware#run(Object[])}} but
-    * with <tt>null</tt> as parameter.
+    * with <code>null</code> as parameter.
     * @return the result of the action
     * @throws E if an error occurs while executing the action
     */

--- a/exo.kernel.component.ext.cache.impl.infinispan.v8/pom.xml
+++ b/exo.kernel.component.ext.cache.impl.infinispan.v8/pom.xml
@@ -99,7 +99,7 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
-          <argLine>@{argLine} ${env.MAVEN_OPTS} -Djava.net.preferIPv4Stack=true -Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</argLine>
+            <argLine>@{argLine} ${env.MAVEN_OPTS} --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED  -Djava.net.preferIPv4Stack=true -Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</argLine>
 					<systemProperties>
 						<!-- Avoid the firewall -->
 						<property>
@@ -113,8 +113,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/exo.kernel.container.ext.provider.impl.guice.v3/pom.xml
+++ b/exo.kernel.container.ext.provider.impl.guice.v3/pom.xml
@@ -59,7 +59,7 @@
          <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <argLine>@{argLine} ${env.MAVEN_OPTS} -Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</argLine>
+              <argLine>@{argLine} ${env.MAVEN_OPTS} --add-opens=java.base/java.lang=ALL-UNNAMED -Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</argLine>
             </configuration>
          </plugin>
          <plugin>

--- a/exo.kernel.container/src/main/java/org/exoplatform/container/ConcurrentContainer.java
+++ b/exo.kernel.container/src/main/java/org/exoplatform/container/ConcurrentContainer.java
@@ -380,7 +380,7 @@ public class ConcurrentContainer extends AbstractInterceptor
    }
 
    /**
-    * If no {@link ComponentAdapter} can be found it returns <tt>null</tt> otherwise
+    * If no {@link ComponentAdapter} can be found it returns <code>null</code> otherwise
     * it first try to get it from the dependency resolution context if it still cannot
     * be found we get the instance from the {@link ComponentAdapter}.
     * @see Container#getComponentInstanceOfType(Class, boolean)

--- a/exo.kernel.container/src/main/java/org/exoplatform/container/configuration/ConfigurationManager.java
+++ b/exo.kernel.container/src/main/java/org/exoplatform/container/configuration/ConfigurationManager.java
@@ -48,8 +48,8 @@ import java.util.Set;
  * dir/to/foo.xml, the configuration manager will try to get the file from file:///path/to/my/dir/to/foo.xml. 
  * Please note that it works also for other prefixes</li>
  * </ul>
- * @author: Tuan Nguyen
- * @version: $Id: ConfigurationManager.java 5799 2006-05-28 17:55:42Z geaz $
+ * @author Tuan Nguyen
+ * @version $Id: ConfigurationManager.java 5799 2006-05-28 17:55:42Z geaz $
  */
 public interface ConfigurationManager
 {

--- a/exo.kernel.container/src/main/java/org/exoplatform/container/configuration/ConfigurationManagerImpl.java
+++ b/exo.kernel.container/src/main/java/org/exoplatform/container/configuration/ConfigurationManagerImpl.java
@@ -43,8 +43,8 @@ import javax.servlet.ServletContext;
 /**
  * Jul 19, 2004
  * 
- * @author: Tuan Nguyen
- * @version: $Id: ConfigurationServiceImpl.java,v 1.8 2004/10/30 02:29:51 tuan08
+ * @author Tuan Nguyen
+ * @version $Id: ConfigurationServiceImpl.java,v 1.8 2004/10/30 02:29:51 tuan08
  *           Exp $
  */
 public class ConfigurationManagerImpl implements ConfigurationManager

--- a/exo.kernel.container/src/main/java/org/exoplatform/container/xml/Configuration.java
+++ b/exo.kernel.container/src/main/java/org/exoplatform/container/xml/Configuration.java
@@ -38,8 +38,8 @@ import java.util.Map;
 /**
  * Jul 19, 2004
  * 
- * @author: Tuan Nguyen
- * @version: $Id: Configuration.java 5799 2006-05-28 17:55:42Z geaz $
+ * @author Tuan Nguyen
+ * @version $Id: Configuration.java 5799 2006-05-28 17:55:42Z geaz $
  */
 public class Configuration implements Cloneable
 {

--- a/exo.kernel.container/src/main/java/org/exoplatform/container/xml/InitParams.java
+++ b/exo.kernel.container/src/main/java/org/exoplatform/container/xml/InitParams.java
@@ -26,8 +26,8 @@ import java.util.List;
 /**
  * Jul 19, 2004
  * 
- * @author: Tuan Nguyen
- * @version: $Id: InitParams.java 5799 2006-05-28 17:55:42Z geaz $
+ * @author Tuan Nguyen
+ * @version $Id: InitParams.java 5799 2006-05-28 17:55:42Z geaz $
  */
 public class InitParams extends HashMap<String, Parameter>
 {

--- a/exo.kernel.container/src/main/java/org/exoplatform/container/xml/ManageableComponents.java
+++ b/exo.kernel.container/src/main/java/org/exoplatform/container/xml/ManageableComponents.java
@@ -24,8 +24,8 @@ import java.util.List;
 /**
  * Jul 19, 2004
  * 
- * @author: Tuan Nguyen
- * @version: $Id: ManageableComponents.java 5799 2006-05-28 17:55:42Z geaz $
+ * @author Tuan Nguyen
+ * @version $Id: ManageableComponents.java 5799 2006-05-28 17:55:42Z geaz $
  */
 public class ManageableComponents
 {

--- a/exo.kernel.container/src/main/java/org/exoplatform/container/xml/ObjectParam.java
+++ b/exo.kernel.container/src/main/java/org/exoplatform/container/xml/ObjectParam.java
@@ -31,8 +31,8 @@ import java.util.List;
 /**
  * Jul 19, 2004
  * 
- * @author: Tuan Nguyen
- * @version: $Id: ObjectParam.java 5799 2006-05-28 17:55:42Z geaz $
+ * @author Tuan Nguyen
+ * @version $Id: ObjectParam.java 5799 2006-05-28 17:55:42Z geaz $
  */
 public class ObjectParam extends Parameter
 {

--- a/exo.kernel.container/src/main/java/org/exoplatform/container/xml/ObjectParameter.java
+++ b/exo.kernel.container/src/main/java/org/exoplatform/container/xml/ObjectParameter.java
@@ -23,8 +23,8 @@ import org.exoplatform.xml.object.XMLObject;
 /**
  * Jul 19, 2004
  * 
- * @author: Tuan Nguyen
- * @version: $Id: ObjectParameter.java 5799 2006-05-28 17:55:42Z geaz $
+ * @author Tuan Nguyen
+ * @version $Id: ObjectParameter.java 5799 2006-05-28 17:55:42Z geaz $
  */
 public class ObjectParameter extends Parameter
 {

--- a/exo.kernel.container/src/main/java/org/exoplatform/container/xml/PropertiesParam.java
+++ b/exo.kernel.container/src/main/java/org/exoplatform/container/xml/PropertiesParam.java
@@ -28,8 +28,8 @@ import java.util.Map;
 /**
  * Jul 19, 2004
  * 
- * @author: Tuan Nguyen
- * @version: $Id: PropertiesParam.java 5799 2006-05-28 17:55:42Z geaz $
+ * @author Tuan Nguyen
+ * @version $Id: PropertiesParam.java 5799 2006-05-28 17:55:42Z geaz $
  */
 public class PropertiesParam extends Parameter
 {

--- a/exo.kernel.container/src/main/java/org/exoplatform/container/xml/ValueParam.java
+++ b/exo.kernel.container/src/main/java/org/exoplatform/container/xml/ValueParam.java
@@ -21,8 +21,8 @@ package org.exoplatform.container.xml;
 /**
  * Jul 19, 2004
  * 
- * @author: Tuan Nguyen
- * @version: $Id: ValueParam.java 5799 2006-05-28 17:55:42Z geaz $
+ * @author Tuan Nguyen
+ * @version $Id: ValueParam.java 5799 2006-05-28 17:55:42Z geaz $
  */
 public class ValueParam extends Parameter
 {

--- a/exo.kernel.container/src/main/java/org/exoplatform/container/xml/ValuesParam.java
+++ b/exo.kernel.container/src/main/java/org/exoplatform/container/xml/ValuesParam.java
@@ -25,8 +25,8 @@ import java.util.List;
 /**
  * Jul 19, 2004
  * 
- * @author: Tuan Nguyen
- * @version: $Id: ValuesParam.java 5799 2006-05-28 17:55:42Z geaz $
+ * @author Tuan Nguyen
+ * @version $Id: ValuesParam.java 5799 2006-05-28 17:55:42Z geaz $
  */
 public class ValuesParam extends Parameter
 {

--- a/exo.kernel.container/src/main/java/org/exoplatform/test/MockConfigurationManagerImpl.java
+++ b/exo.kernel.container/src/main/java/org/exoplatform/test/MockConfigurationManagerImpl.java
@@ -31,8 +31,8 @@ import javax.servlet.ServletContext;
 /**
  * Jul 19, 2004
  * 
- * @author: Tuan Nguyen
- * @version: $Id: MockConfigurationManagerImpl.java 5799 2006-05-28 17:55:42Z
+ * @author Tuan Nguyen
+ * @version $Id: MockConfigurationManagerImpl.java 5799 2006-05-28 17:55:42Z
  *           geaz $
  */
 public class MockConfigurationManagerImpl extends ConfigurationManagerImpl

--- a/exo.kernel.container/src/test/java/org/exoplatform/container/configuration/TestConfigurationService.java
+++ b/exo.kernel.container/src/test/java/org/exoplatform/container/configuration/TestConfigurationService.java
@@ -34,9 +34,9 @@ import java.net.URL;
 
 /*
  * Thu, May 15, 2003 @   
- * @author: Tuan Nguyen
- * @version: $Id: TestConfigurationService.java 5799 2006-05-28 17:55:42Z geaz $
- * @since: 0.0
+ * @author Tuan Nguyen
+ * @version $Id: TestConfigurationService.java 5799 2006-05-28 17:55:42Z geaz $
+ * @since 0.0
  */
 public class TestConfigurationService extends TestCase
 {

--- a/exo.kernel.container/src/test/java/org/exoplatform/container/monitor/TestPortalMonitorService.java
+++ b/exo.kernel.container/src/test/java/org/exoplatform/container/monitor/TestPortalMonitorService.java
@@ -27,9 +27,9 @@ import org.exoplatform.container.monitor.jvm.JVMRuntimeInfo;
 /**
  * Thu, May 15, 2003 @
  * 
- * @author: Tuan Nguyen
- * @version: $Id: TestPortalMonitorService.java 5799 2006-05-28 17:55:42Z geaz $
- * @since: 0.0
+ * @author Tuan Nguyen
+ * @version $Id: TestPortalMonitorService.java 5799 2006-05-28 17:55:42Z geaz $
+ * @since 0.0
  */
 public class TestPortalMonitorService extends TestCase
 {

--- a/exo.kernel.container/src/test/java/org/exoplatform/container/monitor/jvm/TestJVMManagement.java
+++ b/exo.kernel.container/src/test/java/org/exoplatform/container/monitor/jvm/TestJVMManagement.java
@@ -28,9 +28,9 @@ import java.lang.management.ThreadMXBean;
 /**
  * Thu, May 15, 2003 @
  * 
- * @author: Tuan Nguyen
- * @version: $Id: TestJVMManagement.java 5799 2006-05-28 17:55:42Z geaz $
- * @since: 0.0
+ * @author Tuan Nguyen
+ * @version $Id: TestJVMManagement.java 5799 2006-05-28 17:55:42Z geaz $
+ * @since 0.0
  */
 public class TestJVMManagement extends TestCase
 {


### PR DESCRIPTION
prior to this change, when upgrading to JDK 17 kernel throws many exceptions and fails when building: " module java.base does not opens java.util", "Source option 6 is no longer supported. Use 7 or later." ....
. This change will fix these errors.