### PR TITLE
fix: Fix Heavy Addons deployments in Kernel Startup - MEED-1965 - Meeds-io/meeds#829

### DIFF
--- a/exo.kernel.container/src/main/java/org/exoplatform/container/RootContainer.java
+++ b/exo.kernel.container/src/main/java/org/exoplatform/container/RootContainer.java
@@ -906,8 +906,11 @@ public class RootContainer extends ExoContainer implements WebAppListener, Authe
          service.addConfiguration(ContainerUtil.getConfigurationURL("conf/test-configuration.xml"));
       }
       J2EEServerInfo serverEnv = rootContainer.getServerEnvironment();
-      service.addConfiguration(Archive.getConfigurationURL(serverEnv.getApplicationDeployDirectories(),
-         serverEnv.getApplicationDeployArchives(), "META-INF/exo-conf/configuration.xml"));
+      Collection<URL> configurationUrls = Archive.getConfigurationURL(serverEnv.getApplicationDeployDirectories(),
+                                                                      serverEnv.getApplicationDeployArchives(),
+                                                                      "META-INF/exo-conf/configuration.xml");
+      configurationUrls.forEach(configurationUrl -> LOG.info("Including addon configuration file {} in portal container", configurationUrl));
+      service.addConfiguration(configurationUrls);
       String confDir = serverEnv.getExoConfigurationDirectory();
       String overrideConf = confDir + "/configuration.xml";
       File file = new File(overrideConf);

--- a/exo.kernel.container/src/main/java/org/exoplatform/container/monitor/jvm/J2EEServerInfo.java
+++ b/exo.kernel.container/src/main/java/org/exoplatform/container/monitor/jvm/J2EEServerInfo.java
@@ -18,6 +18,7 @@
  */
 package org.exoplatform.container.monitor.jvm;
 
+import org.exoplatform.commons.utils.PropertyManager;
 import org.exoplatform.commons.utils.SecurityHelper;
 import org.exoplatform.container.ar.Archive;
 import org.exoplatform.services.log.ExoLogger;
@@ -71,7 +72,7 @@ public class J2EEServerInfo
 
    private List<String> appDeployDirectories_;
 
-   private Set<Archive> appDeployArchives_;
+   private Set<Archive> appDeployArchives_ = new HashSet<>(Arrays.asList(Archive.EAR, Archive.WAR));
 
    private MBeanServer mbeanServer;
 
@@ -209,7 +210,7 @@ public class J2EEServerInfo
                serverName_ = "tomcat";
                serverHome_ = catalinaHome;
                appDeployDirectories_ = Collections.singletonList(new File(catalinaHome, "webapps").getAbsolutePath());
-               appDeployArchives_ = Collections.singleton(new Archive("war", true, false, null));
+               appDeployArchives_ = Collections.singleton(new Archive("war", PropertyManager.isDevelopping(), false, null));
             }
             else if (testHome != null)
             {
@@ -270,10 +271,6 @@ public class J2EEServerInfo
             {
                if (logEnabled && LOG.isInfoEnabled())
                   LOG.info("No location of the archives has been set");
-            }
-            else if (appDeployArchives_ == null)
-            {
-               appDeployArchives_ = new HashSet<Archive>(Arrays.asList(Archive.EAR, Archive.WAR));
             }
             serverHome_ = serverHome_.replace('\\', '/');
             exoConfDir_ = exoConfDir_.replace('\\', '/');


### PR DESCRIPTION
Prior to this change, the kernel was reading systematically the `META-INF/exo-conf/configuration.xml` file from System Directory instead of **W**eb **AR**chives, assuming that all Web ARchives are deployed before starting the RootContainer. This leads to have sometimes, the RootContainer starting and parsing only some `META-INF/exo-conf/configuration.xml` files from already deployed apps and ignoring the **W**eb **AR**chives that aren't deployed on time.

This change will fix this by reading `META-INF/exo-conf/configuration.xml` from **W**eb **AR**chives instead of directories (when not in **Dev Mode**) to ensure having parsed all configuration files even if **W**eb **AR**chives not unzipped yet.