### PR TITLE
fix: Improve Cache Miss Count Warning Relevancy - MEED-9615 - Meeds-io/meeds#3598

### DIFF
--- a/exo.kernel.component.cache/src/main/java/org/exoplatform/services/cache/concurrent/CacheState.java
+++ b/exo.kernel.component.cache/src/main/java/org/exoplatform/services/cache/concurrent/CacheState.java
@@ -164,9 +164,10 @@ public class CacheState<K extends Serializable, V> {
 
   private void traceExcessiveMissCountRatio() {
     int missCount = config.misses.get();
-    int maxSize = config.getMaxSize();
     int hitCount = config.hits.get();
+    int maxSize = config.getMaxSize();
     if (missCount > MIN_MISS_COUNT
+        && missCount > (hitCount * 2)
         && missCount % Math.max(MIN_MISS_COUNT, Math.min(maxSize, hitCount)) == 0) { // NOSONAR
       log.warn("Cache '{}' seems to have an excessive miss count '{}' (hits count: '{}'), please consider reviewing Max Size '{}' and TTL '{}s' configurations.",
                config.getName(),


### PR DESCRIPTION
Prior to this change, the Cache warning about miss count wasn't considering the ratio between hit and miss counts. This change ensures to not warn about miss count only when it's greater than twice.

Resolves Meeds-io/meeds#3598