### PR TITLE
fix: Clean Input Stream When using getRequestDispatcher - EXO-87249

### DIFF
--- a/exo.kernel.container/src/main/java/org/exoplatform/container/PortalContainer.java
+++ b/exo.kernel.container/src/main/java/org/exoplatform/container/PortalContainer.java
@@ -166,6 +166,10 @@ public class PortalContainer extends ExoContainer
       return webAppContexts;
    }
 
+  public Set<WebAppInitContext> getServletContexts() {
+    return Collections.unmodifiableSet(webAppContexts);
+  }
+
    /**
     * This gives the merged {@link ClassLoader} between the {@link PortalContainerClassLoader} and the
     * {@link ClassLoader} of the web application.

--- a/exo.kernel.container/src/main/java/org/exoplatform/container/PortalContainerContext.java
+++ b/exo.kernel.container/src/main/java/org/exoplatform/container/PortalContainerContext.java
@@ -20,6 +20,7 @@ package org.exoplatform.container;
 
 import org.exoplatform.container.util.Utils;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -245,6 +246,11 @@ class PortalContainerContext implements ServletContext {
          final InputStream is = context.getResourceAsStream(Utils.getPathOnly(path));
          if (is != null)
          {
+            try {
+              is.close();
+            } catch (IOException e) {
+              log("Error closing Input String of file '%s'".formatted(path));
+            }
             // The resource exists within this servlet context
             return context.getRequestDispatcher(path);
          }


### PR DESCRIPTION
Prior to this change, when using the 'getRequestDispatcher' in Wrapped `ServletContext`, the used `InputStream` isn't closed. This change ensure to close the InputStream once the check is made.
At the same time, this gives Access to PortalContainer WebApp Servlet Contexts in order to allow using Request Dispatching directly on Servlet Context.